### PR TITLE
fix: add github token for authentication

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,6 +29,10 @@ jobs:
           git config --global user.email "myong.dev@gmail.com"
           git config --global user.name "damon"
 
+      - name: Update remote URL with GITHUB_TOKEN
+        run: |
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/DevMyong/todo.git
+
       - name: Increment version based on commit type
         run: |
           VERSION=$(cat version.txt)


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow. The change ensures that the remote URL is updated to include the `GITHUB_TOKEN` for authentication purposes.

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R32-R35): Added a step to update the remote URL with `GITHUB_TOKEN` for secure authentication.