### PR TITLE
fix: update versioning to avoid same version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,11 +51,17 @@ jobs:
             patch=$((patch + 1))
           fi
 
+          old_version=$(cat version.txt)
           new_version="$major.$minor.$patch"
+          
+          if [ "$old_version" = "$new_version" ]; then
+          echo "No version bump, skipping commit and tag."
+          else
           echo $new_version > version.txt
           git commit -am "Bump version to $new_version"
           git tag -a "v$new_version" -m "Release version $new_version"
-          git push origin --tags
+          git push origin HEAD --follow-tags
+          fi
 
       - name: List files
         run: ls -al


### PR DESCRIPTION
This pull request includes a change to the version bump logic in the `.github/workflows/workflow.yml` file to prevent unnecessary commits and tags when the version has not changed.

Changes to version bump logic:

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R54-R64): Added a check to compare the old version with the new version, and skip the commit and tag steps if they are the same.