### PR TITLE
fix: change Dockerfile directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . .
+COPY cmd /app/cmd
 RUN cd cmd/server && go build -o server main.go
 
 FROM debian:bookworm-slim
 
 WORKDIR /app
 
-COPY --from=builder /app/cmd/server/server /app/server/server
+COPY --from=builder /app/cmd/server/server /app/server/
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to improve the organization and build process of the Go application. The most important changes include modifying the `COPY` commands to be more specific and adjusting the build output paths.

Improvements to the Dockerfile:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R14): Changed the `COPY` command to copy only the `cmd` directory instead of the entire project directory.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R14): Updated the final `COPY` command to correctly place the built server binary in the `/app/server/` directory.