### PR TITLE
feat: update workflow to add docker push

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -78,7 +78,20 @@ jobs:
           echo "No version bump, skipping commit and tag."
           fi
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build Docker image
         run: |
           VERSION=$(cat version.txt)
-          docker build -t my-app:$VERSION .
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:$VERSION"
+          docker build -t $IMAGE_NAME .
+
+      - name: Push Docker image to Docker Hub
+        run: |
+          VERSION=$(cat version.txt)
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:$VERSION"
+          docker push $IMAGE_NAME


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to integrate Docker Hub for building and pushing Docker images. The most important changes include logging into Docker Hub before building the Docker image and pushing the Docker image to Docker Hub after building it.

Integration with Docker Hub:

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R81-R97): Added a step to log in to Docker Hub using `docker/login-action@v2` with the provided Docker Hub credentials.
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R81-R97): Modified the Docker image build step to use the Docker Hub repository name and tag the image accordingly.
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R81-R97): Added a step to push the Docker image to Docker Hub after building it.