### PR TITLE
fix: workflow of handling version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -75,6 +75,7 @@ jobs:
           else
             echo "No version bump, skipping commit and tag."
           fi
+          echo "VERSION=$new_version" >> $GITHUB_ENV
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
@@ -84,10 +85,10 @@ jobs:
 
       - name: Build Docker image
         run: |
-          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:$new_version"
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:$VERSION"
           docker build -t $IMAGE_NAME .
 
       - name: Push Docker image to Docker Hub
         run: |
-          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:$new_version"
+          IMAGE_NAME="${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:$VERSION"
           docker push $IMAGE_NAME


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/workflow.yml` file. The change adds a line to set the new version in the GitHub environment.

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1R78): Added a line to set `VERSION` in the GitHub environment.