### PR TITLE
feat: set initial env

### DIFF
--- a/.github/workflows/ci-day-labeler.yml
+++ b/.github/workflows/ci-day-labeler.yml
@@ -1,0 +1,16 @@
+name: D-day labeler
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  decrement-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Run d-day-labeler Action
+        uses: devmyong/d-day-labeler@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.23 AS builder
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd /app/cmd
+
+RUN cd /app/cmd/server && go build -o server main.go
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/cmd/server/server /app/server/
+
+EXPOSE 8080
+CMD ["/app/server/server"]


### PR DESCRIPTION
This pull request includes the addition of a new GitHub Actions workflow for labeling issues and a Dockerfile for building and running a Go application. The most important changes are summarized below:

### GitHub Actions Workflow:

* Added a new workflow named `D-day labeler` that runs on a daily schedule to decrement labels using the `devmyong/d-day-labeler` action. This workflow checks out the repository and uses a GitHub token to perform its operations. (.github/workflows/ci-day-labeler.yml)

### Dockerfile:

* Created a multi-stage Dockerfile for building and running a Go application. The first stage uses the `golang:1.23` image to build the application, and the second stage uses the `debian:bookworm-slim` image to run the built application. The application exposes port 8080 and runs the server binary. (Dockerfile)