### PR TITLE
feat(workflow): add PR stats

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,18 +1,15 @@
-name: D day labeler
-
+name: PR Stats
 on:
   workflow_dispatch:
-
-env:
-  GO_VERSION: 1.23
-
 jobs:
-  decrement-labels:
+  pr-stats:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Run d-day-labeler Action
-        uses: devmyong/d-day-labeler@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v4
+      - name: PR Stats
+        uses: naver/pr-stats@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to change the name and functionality of the workflow. The most important changes include renaming the workflow, updating the job and steps, and changing the actions used.

Updates to GitHub Actions workflow:

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L1-R15): Renamed the workflow from "D day labeler" to "PR Stats" and updated the job from `decrement-labels` to `pr-stats`.
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L1-R15): Updated the `checkout` action from `v3` to `v4` and replaced the `d-day-labeler` action with the `pr-stats` action.
* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L1-R15): Added a new step to create a pull request using the `peter-evans/create-pull-request` action.